### PR TITLE
Disable Google SetupWizard

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/config.xml
@@ -33,6 +33,8 @@
         <item>com.google.android.gms/com.google.android.gms.update.SystemUpdateService$Receiver</item>
         <item>com.google.android.gms/com.google.android.gms.update.SystemUpdateService$ActiveReceiver</item>
         <item>com.google.android.gms/com.google.android.gms.update.SystemUpdateService$SecretCodeReceiver</item>
+        <item>com.google.android.setupwizard/.SetupWizardActivity</item>
+        <item>com.google.android.setupwizard/.SetupWizardExitActivity</item>
     </string-array>
 
     <!-- Force enabling of some services that could have been previously disabled -->


### PR DESCRIPTION
Assuming the rom was installed without gapps - on the first boot **after** gapps is installed, the google setup wizard is enabled (even though the device has been marked provisioned) and attempts to run. This causes a series of system ui crashes that makes the device unusable until the activities are disabled or killed.

Also, in the case of a factory reset after gapps has been installed - the google account setup fragment is injected into the aopp setup wizard if gms/gsf is present, so these activities are redundant at best.
